### PR TITLE
Use tail-optimized continuations

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
 export { assert } from "https://deno.land/std@0.158.0/testing/asserts.ts";
-export * from "https://deno.land/x/continuation@0.1.4/mod.ts";
+export * from "https://deno.land/x/continuation@0.1.5/mod.ts";

--- a/instructions.ts
+++ b/instructions.ts
@@ -18,7 +18,7 @@ export function suspend(): Operation<void> {
       return yield function Suspend(_, signal) {
         return shift<Result<void>>(function* (k) {
           if (signal.aborted) {
-            k({ type: "resolved", value: void 0 });
+            k.tail({ type: "resolved", value: void 0 });
           }
         });
       };
@@ -47,9 +47,9 @@ export function action<T>(
             let result = yield* results;
             let destruction = yield* child.destroy();
             if (destruction.type === "rejected") {
-              k(destruction);
+              k.tail(destruction);
             } else {
-              k(result);
+              k.tail(result);
             }
           });
 
@@ -93,7 +93,7 @@ export function spawn<T>(operation: () => Operation<T>): Operation<Task<T>> {
 
           block.enter();
 
-          k({ type: "resolved", value: task });
+          k.tail({ type: "resolved", value: task });
         });
       };
     },
@@ -113,7 +113,7 @@ export function resource<T>(
               *[Symbol.iterator]() {
                 return yield () =>
                   shift<Result<void>>(function* () {
-                    k({ type: "resolved", value });
+                    k.tail({ type: "resolved", value });
                   });
               },
             };
@@ -129,9 +129,9 @@ export function resource<T>(
           yield* reset(function* () {
             let done = yield* block;
             if (done.type === "rejected") {
-              k(done);
+              k.tail(done);
             } else if (done.type === "resolved") {
-              k({
+              k.tail({
                 type: "rejected",
                 error: new Error(
                   `resource exited without ever providing anything`,
@@ -152,7 +152,7 @@ export function getframe(): Operation<Frame> {
     *[Symbol.iterator]() {
       return yield (frame) =>
         shift<Result<Frame>>(function* (k) {
-          k({ type: "resolved", value: frame });
+          k.tail({ type: "resolved", value: frame });
         });
     },
   };


### PR DESCRIPTION
## Motivation
In Effection, we don't actually use the return value of any of the delimited continuations. Because of that, we can avail ourselves of the tail-call optimizations that were introduced here https://github.com/thefrontside/continuation/pull/11

This will cause all synchronous continuations to evaluate on the same run loop. Before, this would cause a stack over flow.

```ts
for (let i = 0; i < 1_000_00; i++;) {
  yield* action(function*(resolve) { resolve() });
}
```

Now, each action continuation happens on the same continuation reduction loop, and so results in another iteration rather than recursion.

## Approach

replace every `k()` with a `k.tail()`