### PR TITLE
fix(channel): do not use the same event for serial subscribers

### DIFF
--- a/channel.ts
+++ b/channel.ts
@@ -17,7 +17,7 @@ export function createChannel<T, TClose = void>(): Channel<T, TClose> {
 
   let send = (item: IteratorResult<T, TClose>) => ({
     *[Symbol.iterator]() {
-      for (let subscriber of subscribers) {
+      for (let subscriber of [...subscribers]) {
         subscriber.deliver(item);
       }
     },


### PR DESCRIPTION
When we subscribe to a channel serially (subscribe, wait for event, then subscribe again) we should not be able to take the same event.

Instead the second subscription should wait for another event from the channel.