### PR TITLE
♻️Remove event stream entirely from action flow

### DIFF
--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "./suite.ts";
-import { expect as $expect, run, sleep, spawn, suspend } from "../mod.ts";
+import {
+  action,
+  expect as $expect,
+  run,
+  sleep,
+  spawn,
+  suspend,
+} from "../mod.ts";
 
 describe("spawn", () => {
   it("can spawn a new child task", async () => {
@@ -175,6 +182,24 @@ describe("spawn", () => {
       "first start",
       "first done",
     ]);
+  });
+
+  it("can catch an error spawned inside of an action", async () => {
+    let error = new Error("boom!");
+    let value = await run(function* () {
+      try {
+        yield* action(function* TheAction() {
+          yield* spawn(function* TheBomb() {
+            yield* sleep(1);
+            throw error;
+          });
+          yield* sleep(5000);
+        });
+      } catch (err) {
+        return err;
+      }
+    });
+    expect(value).toBe(error);
   });
 
   it("halts children on explicit halt", async () => {


### PR DESCRIPTION
## Motivation
Errors were not being propagates to an action when its frame crashed because of a resource and not because there was something wrong with its body or its `reject()` continuation was invoked.

## Approach
It appears that this is a bug in `EventStream` where if close ends up calling itself, then you get a "double close" race error. However, now that `continuation` is quasi tail recursive, I decided to see if we could get by just using that, and it works because all continuations are inherently queued. Less dependencies + less code == more win!