### PR TITLE
add better typing for events on and once

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}

--- a/deno.json
+++ b/deno.json
@@ -3,5 +3,12 @@
     "rules": {
       "exclude": ["prefer-const", "require-yield"]
     }
+  },
+  "compilerOptions": {
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable"
+    ]
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,3 @@
 export { assert } from "https://deno.land/std@0.158.0/testing/asserts.ts";
 export * from "https://deno.land/x/continuation@0.1.5/mod.ts";
+export { expectType } from "https://esm.sh/ts-expect@1.3.0";

--- a/events.ts
+++ b/events.ts
@@ -1,0 +1,39 @@
+import type { Operation, Stream } from "./types.ts";
+import { action, resource, suspend } from "./instructions.ts";
+import { createChannel } from "./channel.ts";
+import { useScope } from "./run/scope.ts";
+
+export function once(target: EventTarget, name: string): Operation<Event> {
+  return action(function* (resolve) {
+    target.addEventListener(name, resolve);
+    try {
+      yield* suspend();
+    } finally {
+      target.removeEventListener(name, resolve);
+    }
+  });
+}
+
+export function on(target: EventTarget, name: string): Stream<Event, never> {
+  return resource(function* (provide) {
+    let { input, output } = createChannel<Event, never>();
+    let scope = yield* useScope();
+    let listener = (event: Event) => scope.run(() => input.send(event));
+
+    target.addEventListener(name, listener);
+
+    try {
+      yield* provide(yield* output);
+    } finally {
+      target.removeEventListener(name, listener);
+    }
+  });
+}
+
+let socket = new WebSocket("wss://localhost:8000");
+
+socket.addEventListener("message", (event) => { event });
+socket.addEventListener("close", (event) => { event });
+
+let messages = on(socket, "message"); //=> Stream<MessageEvent<any>, never>
+let closes = once(socket, "close");  //=> Operation<CloseEvent>

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,20 +1,24 @@
 import { expectType } from '../deps.ts';
 import { on, once } from "../events.ts";
 import { Operation, Stream } from "../types.ts";
-import { describe, expect, it } from "./suite.ts";
+import { describe, it } from "./suite.ts";
 
 
 describe('events', () => {
   const domElement = {} as HTMLElement;
   let socket = {} as WebSocket;
+  
   it('should find event from eventTarget', () => {
     expectType<Operation<CloseEvent>>(once(socket, "close"));
+    // deno-lint-ignore no-explicit-any
     expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
-    
+
     expectType<Operation<MouseEvent>>(once(domElement, "click"));
   });
 
   it("should fall back to event", () => {
-    expectType<Operation<Event>>(once<HTMLElement, any>(domElement, "mycustomevent"));
+    expectType<Operation<Event>>(once(domElement, "mycustomevent"));
+
+    expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,20 @@
+import { expectType } from '../deps.ts';
+import { on, once } from "../events.ts";
+import { Operation, Stream } from "../types.ts";
+import { describe, expect, it } from "./suite.ts";
+
+
+describe('events', () => {
+  const domElement = {} as HTMLElement;
+  let socket = {} as WebSocket;
+  it('should find event from eventTarget', () => {
+    expectType<Operation<CloseEvent>>(once(socket, "close"));
+    expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
+    
+    expectType<Operation<MouseEvent>>(once(domElement, "click"));
+  });
+
+  it("should fall back to event", () => {
+    expectType<Operation<Event>>(once<HTMLElement, any>(domElement, "mycustomevent"));
+  });
+});


### PR DESCRIPTION
With this PR, `on`and `once` can give autocomplete AND also allow the user to fall back to string for the `type` argument of addEventListener

Having the fallback to `string` being type safe makes this now a good story


https://user-images.githubusercontent.com/118328/228165370-9e825dd0-47c7-4bc1-b47f-4673ae185e6f.mp4



